### PR TITLE
Add orchestrator framework rule docs

### DIFF
--- a/.roo/rules-sparc-orchestrator/01-phase-gates.md
+++ b/.roo/rules-sparc-orchestrator/01-phase-gates.md
@@ -1,0 +1,13 @@
+# Phase Gates
+
+Defines mandatory checkpoints required to move through the SPARC lifecycle.
+
+## Gate Sequence
+1. **Specification Complete** – requirements and acceptance criteria approved.
+2. **Architecture Approved** – design decisions documented and reviewed.
+3. **Implementation Verified** – code merged with passing tests and coverage.
+4. **QA Sign-off** – quality benchmarks met and defects addressed.
+
+## Exit Criteria
+- All gates satisfied and logged in `memory-bank/phases/*-status.md`.
+- `memory-bank/current-phase.md` updated to reflect next phase.

--- a/.roo/rules-sparc-orchestrator/02-handoff-protocols.md
+++ b/.roo/rules-sparc-orchestrator/02-handoff-protocols.md
@@ -1,0 +1,13 @@
+# Handoff Protocols
+
+Standard procedures for transferring work between SPARC modes.
+
+## Checklist
+1. Generate brief and context files for the receiving mode.
+2. Compute and record SHA-256 hashes for all handoff artifacts.
+3. Update `.roo/handoffs/next.json` with `nextSlug`, cursor, and brief hash.
+4. Log coordination in `memory-bank/phases/orchestrator-status.md`.
+
+## Validation
+- Incoming handoffs must match recorded hashes before execution.
+- Each mode acknowledges receipt in the memory bank log.

--- a/.roo/rules-sparc-orchestrator/03-quality-validation.md
+++ b/.roo/rules-sparc-orchestrator/03-quality-validation.md
@@ -1,0 +1,14 @@
+# Quality Validation
+
+Mechanisms to enforce baseline quality before phase transitions.
+
+## Requirements
+- All automated tests pass.
+- Minimum 80% coverage as reported by test suite.
+- Security review completed with no critical findings.
+- Documentation updated and linked to relevant deliverables.
+
+## Verification Steps
+1. Run `pytest` or equivalent test runner.
+2. Capture coverage reports and attach to memory bank.
+3. Update `memory-bank/phases/qa-status.md` with results.

--- a/.roo/rules-sparc-orchestrator/04-emergency-procedures.md
+++ b/.roo/rules-sparc-orchestrator/04-emergency-procedures.md
@@ -1,0 +1,14 @@
+# Emergency Procedures
+
+Contingency plan when critical issues threaten progress or security.
+
+## Trigger Conditions
+- Failing tests on main branch.
+- Newly discovered security vulnerabilities.
+- Deployment blockers or data integrity issues.
+
+## Response
+1. Halt all active handoffs and freeze `.roo/handoffs/next.json` cursor.
+2. Record incident in `memory-bank/phases/orchestrator-status.md` with severity.
+3. Create `emergency.md` summarizing impact and mitigation plan.
+4. Coordinate rollback or hotfix with relevant specialist modes.

--- a/.roo/rules-sparc-orchestrator/instructions.md
+++ b/.roo/rules-sparc-orchestrator/instructions.md
@@ -9,3 +9,9 @@
 - Coordinate mode handoffs with clear context and next actions
 - Read only relevant context files for current phase (avoid loading entire project state)
 - Verify .rooignore is properly configured before starting any development phase
+
+## Framework References
+- [Phase Gates](01-phase-gates.md)
+- [Handoff Protocols](02-handoff-protocols.md)
+- [Quality Validation](03-quality-validation.md)
+- [Emergency Procedures](04-emergency-procedures.md)

--- a/.roomodes
+++ b/.roomodes
@@ -6,7 +6,13 @@
       "description": "Master coordinator managing SPARC phases and quality gates",
       "whenToUse": "Use across all phases to coordinate SPARC milestones and handoffs.",
       "roleDefinition": "Coordinates development phases, manages handoffs between specialist modes, and ensures systematic progression through SPARC methodology.",
-      "customInstructions": ".roo/rules-sparc-orchestrator/instructions.md",
+      "customInstructions": [
+        ".roo/rules-sparc-orchestrator/instructions.md",
+        ".roo/rules-sparc-orchestrator/01-phase-gates.md",
+        ".roo/rules-sparc-orchestrator/02-handoff-protocols.md",
+        ".roo/rules-sparc-orchestrator/03-quality-validation.md",
+        ".roo/rules-sparc-orchestrator/04-emergency-procedures.md"
+      ],
       "groups": [
         "read",
         [


### PR DESCRIPTION
## Summary
- add phase gate, handoff, quality, and emergency playbooks for the SPARC orchestrator
- reference the new playbooks in orchestrator instructions and mode configuration

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b4fad6f508322b67250230f0617de