### PR TITLE
chore: add quality checks

### DIFF
--- a/.github/workflows/sparc-quality.yml
+++ b/.github/workflows/sparc-quality.yml
@@ -1,0 +1,31 @@
+name: SPARC Quality Checks
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run quality checks
+        run: ./.tools/quality-check.sh
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Bandit security scan
+        run: |
+          pip install bandit
+          bandit -r .
+
+  documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run markdown lint
+        run: |
+          npm install -g markdownlint-cli
+          markdownlint '**/*.md' --ignore AGENTS.md

--- a/.tools/quality-check.sh
+++ b/.tools/quality-check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXCLUDE_DIRS=".git|.tools|memory-bank|.roo"
+EXIT_CODE=0
+
+# Search for TODOs excluding specific directories
+TODO_FILES=$(grep -R "TODO" "$REPO_ROOT" --line-number --exclude-dir={.git,.tools,memory-bank,.roo} || true)
+if [[ -n "$TODO_FILES" ]]; then
+  echo "TODOs found:"
+  echo "$TODO_FILES"
+  EXIT_CODE=1
+fi
+
+# Search for potential secrets
+SECRET_PATTERNS='(AWS_SECRET_ACCESS_KEY|API_KEY|SECRET_KEY|PASSWORD|PRIVATE KEY)'
+SECRET_FILES=$(grep -R -E "$SECRET_PATTERNS" "$REPO_ROOT" --line-number --exclude-dir={.git,.tools,memory-bank,.roo} || true)
+if [[ -n "$SECRET_FILES" ]]; then
+  echo "Potential secrets found:"
+  echo "$SECRET_FILES"
+  EXIT_CODE=1
+fi
+
+# Check for files larger than 1MB
+LARGE_FILES=$(find "$REPO_ROOT" -type f -not -path "*/.git/*" -not -path "*/memory-bank/*" -not -path "*/.roo/*" -size +1M || true)
+if [[ -n "$LARGE_FILES" ]]; then
+  echo "Files exceeding 1MB:"
+  echo "$LARGE_FILES"
+  EXIT_CODE=1
+fi
+
+if [[ "$EXIT_CODE" -ne 0 ]]; then
+  echo "Quality checks failed."
+else
+  echo "All quality checks passed."
+fi
+exit $EXIT_CODE

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # SPARC12
+
 Roo code dev framework


### PR DESCRIPTION
## Summary
- add a quality-check script scanning for TODOs, secrets, and oversized files
- run quality, security, and documentation checks in CI
- tidy README heading spacing for markdown lint

## Testing
- `./.tools/quality-check.sh`
- `echo 'TODO fix this' > temp.txt && ./.tools/quality-check.sh || echo 'quality check failed as expected'`
- `bandit -r .`
- `markdownlint '**/*.md' --ignore AGENTS.md`


------
https://chatgpt.com/codex/tasks/task_e_689b565f83f083229ef3436c55c44097