### PR TITLE
Use explicit checks in tests instead of assert statements

### DIFF
--- a/tests/test_security_fixes.py
+++ b/tests/test_security_fixes.py
@@ -29,13 +29,26 @@ def test_update_embeddings_and_search():
     conn, search = setup_embeddings_db()
     search.update_embeddings("decisions", [1])
     rows = conn.execute("SELECT item_type, item_id FROM item_embeddings").fetchall()
-    assert rows and rows[0]["item_id"] == 1
+    if not rows:
+        raise AssertionError("No rows returned from embeddings table")
+    if rows[0]["item_id"] != 1:
+        raise AssertionError(
+            f"Expected item_id 1, got {rows[0]['item_id']}"
+        )
 
     results = search.semantic_search("sum1", filter_item_types=["decisions"])
-    assert results and results[0].item_id == 1
+    if not results:
+        raise AssertionError("No search results returned")
+    if results[0].item_id != 1:
+        raise AssertionError(
+            f"Expected item_id 1, got {results[0].item_id}"
+        )
 
     results_none = search.semantic_search("sum1", filter_item_types=["progress"])
-    assert results_none == []
+    if results_none:
+        raise AssertionError(
+            f"Expected no results, got {len(results_none)}"
+        )
 
 
 def setup_server() -> ContextPortalSPARCServer:
@@ -56,10 +69,21 @@ def test_update_progress_and_search_custom_data():
     row = c.execute(
         "SELECT status, description FROM progress WHERE id = ?", (progress_id,)
     ).fetchone()
-    assert row["status"] == "closed"
-    assert row["description"] == "done"
+    if row["status"] != "closed":
+        raise AssertionError(
+            f"Expected status 'closed', got {row['status']}"
+        )
+    if row["description"] != "done":
+        raise AssertionError(
+            f"Expected description 'done', got {row['description']}"
+        )
 
     server.log_custom_data("cat", "k1", {"foo": "bar"})
     results = server.search_custom_data_value_fts("bar", category_filter="cat", limit=5)
-    assert results and results[0]["category"] == "cat"
+    if not results:
+        raise AssertionError("No custom data search results returned")
+    if results[0]["category"] != "cat":
+        raise AssertionError(
+            f"Expected category 'cat', got {results[0]['category']}"
+        )
 


### PR DESCRIPTION
## Summary
- replace bare assert statements in `tests/test_security_fixes.py` with explicit checks that raise `AssertionError`

## Testing
- `python -m pytest tests/test_security_fixes.py`
- `./.tools/quality-check.sh`
- `bandit -r .`
- `npx -y markdownlint-cli "**/*.md" --ignore AGENTS.md` *(fails: multiple markdown issues in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a44d805c8322a46c6e9ec501248d