### PR TITLE
Implement safe SQLite connection management

### DIFF
--- a/tests/test_connection_management.py
+++ b/tests/test_connection_management.py
@@ -1,0 +1,38 @@
+import os
+import sqlite3
+import tempfile
+import sys
+import pathlib
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "sparc-server"))
+
+from specialized_mcp_server import ContextPortalSPARCServer, DatabaseConnectionError
+
+
+def test_context_manager_closes_connection() -> None:
+    tmpdir = tempfile.mkdtemp()
+    db_path = os.path.join(tmpdir, "ctx.db")
+    with ContextPortalSPARCServer(workspace_dir=tmpdir, db_path=db_path) as server:
+        assert server._conn is not None
+        server._conn.execute("SELECT 1")
+    assert server._conn is None
+
+
+def test_close_method_closes_connection() -> None:
+    tmpdir = tempfile.mkdtemp()
+    server = ContextPortalSPARCServer(workspace_dir=tmpdir)
+    assert server._conn is not None
+    server.close()
+    assert server._conn is None
+
+
+def test_connect_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def bad_connect(*args, **kwargs):
+        raise sqlite3.OperationalError("fail")
+
+    monkeypatch.setattr(sqlite3, "connect", bad_connect)
+    tmpdir = tempfile.mkdtemp()
+    with pytest.raises(DatabaseConnectionError):
+        ContextPortalSPARCServer(workspace_dir=tmpdir)


### PR DESCRIPTION
## Summary
- add `DatabaseConnectionError` and context-managed SQLite connections in `ContextPortalSPARCServer`
- ensure connections close safely via context manager and destructor
- cover connection lifecycle with new tests

## Testing
- `pytest -q`
- `bandit -r . -q` *(fails: B101 assert_used in tests)*
- `./.tools/quality-check.sh`
- `markdownlint '**/*.md' --ignore AGENTS.md` *(fails: many MD013 line-length and other lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a0ad74ae608322a2afcdba777cf8f4