### PR TITLE
refactor: document OpenAI embedding dimensions

### DIFF
--- a/tests/test_openai_embedding_provider.py
+++ b/tests/test_openai_embedding_provider.py
@@ -3,6 +3,7 @@ import sys
 import pathlib
 import numpy as np
 import pytest
+import logging
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "sparc-server"))
 
@@ -48,3 +49,15 @@ def test_encode_returns_embeddings(monkeypatch):
     result = provider.encode(["a"])
     assert isinstance(result, np.ndarray)
     assert result.shape == (1, 2)
+
+
+def test_model_dimensions_and_default(monkeypatch, caplog):
+    monkeypatch.setenv("OPENAI_API_TOKEN", "k")
+    monkeypatch.setattr(ee, "AsyncOpenAI", DummyClient)
+    provider = ee.OpenAIEmbeddingProvider(model="text-embedding-3-large")
+    assert provider.get_dimension() == ee.OPENAI_EMBEDDING_DIMENSIONS["text-embedding-3-large"]
+
+    with caplog.at_level(logging.WARNING):
+        provider = ee.OpenAIEmbeddingProvider(model="unknown-model")
+        assert provider.get_dimension() == ee.DEFAULT_OPENAI_EMBEDDING_DIMENSION
+        assert "Unknown OpenAI model" in caplog.text


### PR DESCRIPTION
## Summary
- replace hard-coded OpenAI embedding dimensions with documented constants
- warn and default to standard dimension for unknown OpenAI models
- test for known and unknown model dimensions

## Testing
- `pytest -q`
- `./.tools/quality-check.sh`
- `bandit -r .`
- `markdownlint '**/*.md' --ignore AGENTS.md` *(fails: line-length and formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b7a7248483229b62017c156dda75