### PR TITLE
fix: secure SQL limit clauses

### DIFF
--- a/sparc-server/specialized_mcp_server.py
+++ b/sparc-server/specialized_mcp_server.py
@@ -358,12 +358,13 @@ class ContextPortalSPARCServer:
             query_parts.append("WHERE " + " AND ".join(conditions))
 
         query_parts.append("ORDER BY id DESC")
-
         if limit is not None:
-            if not isinstance(limit, int) or limit <= 0:
-                raise QueryBuilderError("limit must be a positive integer")
-            query_parts.append(f"LIMIT {limit}")
-
+            if not isinstance(limit, int):
+                raise QueryBuilderError("limit must be an integer")
+            if limit < 0:
+                raise QueryBuilderError("limit must be non-negative")
+            query_parts.append("LIMIT ?")
+            params.append(limit)
         return " ".join(query_parts), params
 
     def get_decisions(
@@ -437,8 +438,13 @@ class ContextPortalSPARCServer:
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY id DESC"
-        if limit:
-            query += f" LIMIT {int(limit)}"
+        if limit is not None:
+            if not isinstance(limit, int):
+                raise ValueError("limit must be an integer or None")
+            if limit < 0:
+                raise ValueError("limit cannot be negative")
+            query += " LIMIT ?"
+            params.append(limit)
         rows = c.execute(query, params).fetchall()
         return [dict(row) for row in rows]
 
@@ -503,8 +509,13 @@ class ContextPortalSPARCServer:
         if conditions:
             query += " WHERE " + " AND ".join(conditions)
         query += " ORDER BY id DESC"
-        if limit:
-            query += f" LIMIT {int(limit)}"
+        if limit is not None:
+            if not isinstance(limit, int):
+                raise ValueError("limit must be an integer or None")
+            if limit < 0:
+                raise ValueError("limit cannot be negative")
+            query += " LIMIT ?"
+            params.append(limit)
         rows = c.execute(query, params).fetchall()
         return [dict(row) for row in rows]
 

--- a/tests/test_get_decisions_query_builder.py
+++ b/tests/test_get_decisions_query_builder.py
@@ -30,16 +30,22 @@ def test_build_decisions_query_filters_limit() -> None:
         tags_filter_include_all=["a"], tags_filter_include_any=["b"], limit=5
     )
     expected = (
-        "SELECT * FROM decisions WHERE tags LIKE ? AND (tags LIKE ?) ORDER BY id DESC LIMIT 5"
+        "SELECT * FROM decisions WHERE tags LIKE ? AND (tags LIKE ?) ORDER BY id DESC LIMIT ?"
     )
     assert query == expected
-    assert params == ["%a%", "%b%"]
+    assert params == ["%a%", "%b%", 5]
 
 
 def test_build_decisions_query_invalid_tags() -> None:
     server = _server()
     with pytest.raises(QueryBuilderError):
         server.build_decisions_query(tags_filter_include_all="bad")
+
+
+def test_build_decisions_query_invalid_limit() -> None:
+    server = _server()
+    with pytest.raises(QueryBuilderError):
+        server.build_decisions_query(limit="1; DROP TABLE decisions")
 
 
 def test_get_decisions_filters_results() -> None:

--- a/tests/test_limit_clauses.py
+++ b/tests/test_limit_clauses.py
@@ -1,0 +1,33 @@
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "sparc-server"))
+from specialized_mcp_server import ContextPortalSPARCServer
+
+
+def _server() -> ContextPortalSPARCServer:
+    tmpdir = tempfile.mkdtemp()
+    return ContextPortalSPARCServer(workspace_dir=tmpdir)
+
+
+def test_get_progress_limit_parameterized() -> None:
+    server = _server()
+    server.log_progress("desc1", "open")
+    server.log_progress("desc2", "open")
+    rows = server.get_progress(limit=1)
+    assert len(rows) == 1
+    with pytest.raises(ValueError):
+        server.get_progress(limit="1; DROP TABLE progress")
+
+
+def test_get_system_patterns_limit_parameterized() -> None:
+    server = _server()
+    server.log_system_pattern("p1", "d1")
+    server.log_system_pattern("p2", "d2")
+    rows = server.get_system_patterns(limit=1)
+    assert len(rows) == 1
+    with pytest.raises(ValueError):
+        server.get_system_patterns(limit="1; DROP TABLE system_patterns")


### PR DESCRIPTION
## Summary
- validate and parameterize dynamic LIMIT clauses to prevent SQL injection
- test SQL limit handling for decisions, progress, and system patterns

## Testing
- `pytest`
- `./.tools/quality-check.sh`
- `bandit -r .`
- `markdownlint '**/*.md' --ignore AGENTS.md` *(fails: long lines and formatting issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a1419008ec832294df38d9a8c02708